### PR TITLE
Add check on PRs

### DIFF
--- a/.github/workflows/post-merge-build-and-upload.yaml
+++ b/.github/workflows/post-merge-build-and-upload.yaml
@@ -1,4 +1,4 @@
-name: Build & push
+name: Tag, Build and upload post-merge
 on:
   pull_request:
     types: [closed]

--- a/.github/workflows/pr-commit-run-checks.yaml
+++ b/.github/workflows/pr-commit-run-checks.yaml
@@ -1,0 +1,12 @@
+name: Run pull request checks
+on:
+  - pull_request
+jobs:
+  check_semver_label:
+    name: Check for semantic version label
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://agilepathway/pull-request-label-checker:latest
+        with:
+          one_of: major,minor,patch
+          repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add a required check for a semantic label of `major`, `minor`, or `patch`, so that versioning can be automated post-merge.